### PR TITLE
Support more formats, and a resize action

### DIFF
--- a/lib/escpos/image.rb
+++ b/lib/escpos/image.rb
@@ -72,11 +72,10 @@ module Escpos
     def convert_to_monochrome(image_path, opts = {})
       image = MiniMagick::Image.open(image_path)
       image.collapse!  # Get the first image out of animated gifs
-      image.combine_options do |c| # Optimise a few actions 
-         if opts.key?(:resize)
-            c.resize opts.fetch(:resize)     # Resize to fit on page (maintains aspect, fits to largest side)
-         end
-         c.grayscale 'Rec709Luma'                       # Grayscale
+      image.combine_options do |c| # Optimise a few actions
+         c.rotate opts.fetch(:rotate) if opts.key?(:rotate)   # Rotate if required
+         c.resize opts.fetch(:resize) if opts.key?(:resize)   # Resize to fit the page
+         c.grayscale 'Rec709Luma'                             # Grayscale
          if opts.fetch(:dither, true)
            c.monochrome # Dither is ON by default
          else
@@ -90,6 +89,5 @@ module Escpos
       image.format 'png' # Always to PNG for ChunkyPNG to work
       image
     end
-
   end
 end

--- a/lib/escpos/image.rb
+++ b/lib/escpos/image.rb
@@ -73,8 +73,8 @@ module Escpos
       image = MiniMagick::Image.open(image_path)
       image.collapse!  # Get the first image out of animated gifs
       image.combine_options do |c| # Optimise a few actions 
-         unless opts.fetch(:resize).nil?
-            c.resize opts.fetch(:resize)        # Resize to fit on page (maintains aspect, fits to largest side)
+         if opts.key?(:resize)
+            c.resize opts.fetch(:resize)     # Resize to fit on page (maintains aspect, fits to largest side)
          end
          c.grayscale 'Rec709Luma'                       # Grayscale
          if opts.fetch(:dither, true)


### PR DESCRIPTION
Some tweaks to the monochrome actions to allow

* Multiple image formats can be used (By forcing output encoding to PNG)
* Optimised some actions with the combine_options so mogrify runs fewer times
* Added resize options to allow code to shrink/expand images to fit
* Fixed the `+dither` option which was logically reversed