### PR TITLE
Principle of Least Surprise: compose_alpha should be true by default

### DIFF
--- a/lib/escpos/image.rb
+++ b/lib/escpos/image.rb
@@ -41,7 +41,7 @@ module Escpos
             ChunkyPNG::Color.b(px)
           px = (r + b + g) / 3
           # Alpha is flattened with convert_to_monochrome option
-          if options.fetch(:compose_alpha, false)
+          if options.fetch(:compose_alpha, true)
             bg_color = options.fetch(:compose_alpha_bg, 255)
             a_quot = a / 255.0
             px = (((1 - a_quot) * bg_color) + (a_quot * px)).to_i


### PR DESCRIPTION
If I pass in a PNG image, I expect alpha to be evaluated and handled properly. Every PNG renderer in existence does this automatically.

(I also expect background to be white which is already the default.)