### PR TITLE
Improvement to handling :processor arg value

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or
 
 # Creating image from path
 image = Escpos::Image.new 'path/to/image.png', {
-  processor: "ChunkyPng" # or MiniMagick
+  processor: :chunky_png # or :mini_magick
   # ... other options, see following sections
 }
 

--- a/lib/escpos/image.rb
+++ b/lib/escpos/image.rb
@@ -55,10 +55,8 @@ module Escpos
     private
 
     def get_processor_klass(image, processor)
-      case image
-      when ::MiniMagick::Image then return ImageProcessors::MiniMagick
-      when ::ChunkyPng::Image then return ImageProcessors::ChunkyPng
-      end
+      klass = get_processor_klass_from_image(image)
+      return klass if klass
 
       return default_processor_klass unless processor
 
@@ -66,6 +64,13 @@ module Escpos
       when 'minimagick' then ImageProcessors::MiniMagick
       when 'chunkypng' then ImageProcessors::ChunkyPng
       else raise("Escpos:Image unknown processor value #{processor.inspect}")
+      end
+    end
+
+    def get_processor_klass_from_image(image)
+      case image
+      when ::MiniMagick::Image then ImageProcessors::MiniMagick
+      when ::ChunkyPNG::Image then ImageProcessors::ChunkyPng
       end
     end
 

--- a/lib/escpos/image.rb
+++ b/lib/escpos/image.rb
@@ -16,7 +16,7 @@ module Escpos
     def initialize(image_or_path, options = {})
       @options = options
 
-      processor_klass = get_processor_klass(options[:processor])
+      processor_klass = get_processor_klass(image_or_path, options[:processor])
       @processor = processor_klass.new(image_or_path, options)
 
       @processor.process!
@@ -54,7 +54,12 @@ module Escpos
 
     private
 
-    def get_processor_klass(processor)
+    def get_processor_klass(image, processor)
+      case image
+      when ::MiniMagick::Image then return ImageProcessors::MiniMagick
+      when ::ChunkyPng::Image then return ImageProcessors::ChunkyPng
+      end
+
       return default_processor_klass unless processor
 
       case processor.to_s.downcase.gsub(/[_-]/, '')

--- a/test/lib/escpos/image_test.rb
+++ b/test/lib/escpos/image_test.rb
@@ -40,7 +40,20 @@ class ImageTest < Minitest::Test
     assert_equal IO.binread(file), @printer.to_escpos
   end
 
-  def test_default_processor_klass
+  def test_processor_chunky_png_image
+    image = Escpos::Image.new ChunkyPNG::Image.new(8, 8), grayscale: true,
+                              compose_alpha: true, extent: true
+    assert_equal image.processor.class, Escpos::ImageProcessors::ChunkyPng
+  end
+
+  def test_processor_mini_magick_image
+    image_path = File.join(__dir__, '../../fixtures/tux_mono.png')
+    image = Escpos::Image.new MiniMagick::Image.new(image_path), grayscale: true,
+                              compose_alpha: true, extent: true
+    assert_equal image.processor.class, Escpos::ImageProcessors::MiniMagick
+  end
+
+  def test_processor_default
     image_path = File.join(__dir__, '../../fixtures/tux_alpha.png')
     image = Escpos::Image.new image_path, grayscale: true,
                               compose_alpha: true, extent: true

--- a/test/lib/escpos/image_test.rb
+++ b/test/lib/escpos/image_test.rb
@@ -40,4 +40,10 @@ class ImageTest < Minitest::Test
     assert_equal IO.binread(file), @printer.to_escpos
   end
 
+  def test_default_processor_klass
+    image_path = File.join(__dir__, '../../fixtures/tux_alpha.png')
+    image = Escpos::Image.new image_path, grayscale: true,
+                              compose_alpha: true, extent: true
+    assert_equal image.processor.class, Escpos::ImageProcessors::MiniMagick
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,4 +5,7 @@ require 'minitest/autorun'
 require 'pp'
 
 require 'escpos'
+require 'chunky_png'
+require 'mini_magick'
+
 require File.expand_path('../../lib/escpos/image.rb', __FILE__)


### PR DESCRIPTION
- If the first arg to `Escpos::Image.new` is either a ChunkyPNG::Image or MiniMagick::Image, use that processor automatically.
- If :processor arg is not set, choose default processor using either MiniMagick or ChunkyPNG (whichever one is available). Default is MiniMagick if both are installed.
- :processor arg is now more permissive (allows symbol or string, case-insensitive and underscore/hyphen-insensitive.) I've updated the readme to use snake_case Symbols, however, the previous values e.g. "ChunkyPng" still work.
- Remove usage of `const_get`, which is a potential security liability although in this case it looks fine.